### PR TITLE
chore: add Docker Compose for local development

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,68 @@
+services:
+  dev:
+    image: node:20-alpine
+    working_dir: /app
+    volumes:
+      - .:/app
+      - node_modules:/app/node_modules
+    ports:
+      - "5173:5173"
+    command: sh -c "npm install && npm run dev -- --host 0.0.0.0"
+    environment:
+      - VITE_EMAILJS_PUBLIC_KEY=${VITE_EMAILJS_PUBLIC_KEY:-}
+      - VITE_EMAILJS_SERVICE_ID=${VITE_EMAILJS_SERVICE_ID:-}
+      - VITE_EMAILJS_TEMPLATE_ID=${VITE_EMAILJS_TEMPLATE_ID:-}
+
+  test:
+    image: node:20-alpine
+    working_dir: /app
+    volumes:
+      - .:/app
+      - node_modules:/app/node_modules
+    command: sh -c "npm install && npm run test -- --run"
+    profiles:
+      - test
+
+  lint:
+    image: node:20-alpine
+    working_dir: /app
+    volumes:
+      - .:/app
+      - node_modules:/app/node_modules
+    command: sh -c "npm install && npm run lint"
+    profiles:
+      - lint
+
+  build:
+    image: node:20-alpine
+    working_dir: /app
+    volumes:
+      - .:/app
+      - node_modules:/app/node_modules
+      - ./dist:/app/dist
+    command: sh -c "npm install && npm run build"
+    environment:
+      - VITE_EMAILJS_PUBLIC_KEY=${VITE_EMAILJS_PUBLIC_KEY:-}
+      - VITE_EMAILJS_SERVICE_ID=${VITE_EMAILJS_SERVICE_ID:-}
+      - VITE_EMAILJS_TEMPLATE_ID=${VITE_EMAILJS_TEMPLATE_ID:-}
+    profiles:
+      - build
+
+  preview:
+    image: node:20-alpine
+    working_dir: /app
+    volumes:
+      - .:/app
+      - node_modules:/app/node_modules
+    ports:
+      - "4173:4173"
+    command: sh -c "npm install && npm run build && npm run preview -- --host 0.0.0.0"
+    environment:
+      - VITE_EMAILJS_PUBLIC_KEY=${VITE_EMAILJS_PUBLIC_KEY:-}
+      - VITE_EMAILJS_SERVICE_ID=${VITE_EMAILJS_SERVICE_ID:-}
+      - VITE_EMAILJS_TEMPLATE_ID=${VITE_EMAILJS_TEMPLATE_ID:-}
+    profiles:
+      - preview
+
+volumes:
+  node_modules:


### PR DESCRIPTION
## Summary
- Add `compose.yml` with services for development workflow
- `dev` service: hot-reload development server on port 5173
- `test` service: runs Vitest test suite (profile: test)
- `lint` service: runs ESLint (profile: lint)
- `build` service: creates production build (profile: build)
- `preview` service: preview production build on port 4173 (profile: preview)
- Uses named volume for node_modules to avoid conflicts

## Usage
```bash
# Start dev server
docker compose up dev

# Run tests
docker compose --profile test up test

# Run linter
docker compose --profile lint up lint

# Create production build
docker compose --profile build up build

# Preview production build
docker compose --profile preview up preview
```

## Test plan
- [ ] Run `docker compose up dev` - dev server should start on port 5173
- [ ] Run `docker compose --profile test up test` - tests should pass
- [ ] Run `docker compose --profile build up build` - build should succeed