### PR TITLE
feat(portfolio): add modular portfolio components with filtering

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "tailwindcss": "^3.4.10",
         "terser": "^5.39.0",
         "vite": "^7.3.1",
-        "vite-plugin-obfuscator": "^1.0.5",
+        "vite-plugin-bundle-obfuscator": "^1.10.0",
         "vite-plugin-pages": "^0.32.3",
         "vitest": "^3.0.9",
         "vue-eslint-parser": "^10.1.1"
@@ -989,6 +989,34 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@inversifyjs/common": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@inversifyjs/common/-/common-1.3.3.tgz",
+      "integrity": "sha512-ZH0wrgaJwIo3s9gMCDM2wZoxqrJ6gB97jWXncROfYdqZJv8f3EkqT57faZqN5OTeHWgtziQ6F6g3L8rCvGceCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@inversifyjs/core": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@inversifyjs/core/-/core-1.3.4.tgz",
+      "integrity": "sha512-gCCmA4BdbHEFwvVZ2elWgHuXZWk6AOu/1frxsS+2fWhjEk2c/IhtypLo5ytSUie1BCiT6i9qnEo4bruBomQsAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inversifyjs/common": "1.3.3",
+        "@inversifyjs/reflect-metadata-utils": "0.2.3"
+      }
+    },
+    "node_modules/@inversifyjs/reflect-metadata-utils": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@inversifyjs/reflect-metadata-utils/-/reflect-metadata-utils-0.2.3.tgz",
+      "integrity": "sha512-d3D0o9TeSlvaGM2I24wcNw/Aj3rc4OYvHXOKDC09YEph5fMMiKd6fq1VTQd9tOkDNWvVbw+cnt45Wy9P/t5Lvw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "reflect-metadata": "0.2.2"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -1008,9 +1036,9 @@
       }
     },
     "node_modules/@javascript-obfuscator/escodegen": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@javascript-obfuscator/escodegen/-/escodegen-2.3.0.tgz",
-      "integrity": "sha512-QVXwMIKqYMl3KwtTirYIA6gOCiJ0ZDtptXqAv/8KWLG9uQU2fZqTVy7a/A5RvcoZhbDoFfveTxuGxJ5ibzQtkw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@javascript-obfuscator/escodegen/-/escodegen-2.3.1.tgz",
+      "integrity": "sha512-Z0HEAVwwafOume+6LFXirAVZeuEMKWuPzpFbQhCEU9++BMz0IwEa9bmedJ+rMn/IlXRBID9j3gQ0XYAa6jM10g==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -1103,6 +1131,17 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -1937,9 +1976,9 @@
       "license": "MIT"
     },
     "node_modules/@types/validator": {
-      "version": "13.12.3",
-      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.12.3.tgz",
-      "integrity": "sha512-2ipwZ2NydGQJImne+FhNdhgRM37e9lCev99KnqkbFHd94Xn/mErARWI1RSLem1QA19ch5kOhzIZd7e8CA2FI8g==",
+      "version": "13.15.10",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.10.tgz",
+      "integrity": "sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==",
       "dev": true,
       "license": "MIT"
     },
@@ -2632,6 +2671,48 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ansi-regex": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
@@ -2751,16 +2832,17 @@
       }
     },
     "node_modules/assert": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
-      "integrity": "sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
+      "integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "es6-object-assign": "^1.1.0",
-        "is-nan": "^1.2.1",
-        "object-is": "^1.0.1",
-        "util": "^0.12.0"
+        "call-bind": "^1.0.2",
+        "is-nan": "^1.3.2",
+        "object-is": "^1.1.5",
+        "object.assign": "^4.1.4",
+        "util": "^0.12.5"
       }
     },
     "node_modules/assertion-error": {
@@ -2779,6 +2861,17 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/atomically": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.1.0.tgz",
+      "integrity": "sha512-+gDffFXRW6sl/HCwbta7zK4uNqbPjv4YJEAdz7Vu+FLQHe77eZ4bvbJGi4hE0QPeJlMYMA3piXEr1UL3dAwx7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stubborn-fs": "^2.0.0",
+        "when-exit": "^2.1.4"
+      }
     },
     "node_modules/autoprefixer": {
       "version": "10.4.20",
@@ -3076,9 +3169,9 @@
       }
     },
     "node_modules/chance": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/chance/-/chance-1.1.9.tgz",
-      "integrity": "sha512-TfxnA/DcZXRTA4OekA2zL9GH8qscbbl6X0ZqU4tXhGveVY/mXWvEQLt5GwZcYXTEyEFflVtj+pG8nc8EwSm1RQ==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/chance/-/chance-1.1.13.tgz",
+      "integrity": "sha512-V6lQCljcLznE7tUYUM9EOAnnKXbctE6j/rdQkYOHIWbfGQbrzTsAXNW9CdU5XCo4ArXQCj/rb6HgxPlmGJcaUg==",
       "dev": true,
       "license": "MIT"
     },
@@ -3151,15 +3244,15 @@
       }
     },
     "node_modules/class-validator": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.1.tgz",
-      "integrity": "sha512-2VEG9JICxIqTpoK1eMzZqaV+u/EiwEJkMGzTrZf6sU/fwsnOITVgYJ8yojSy6CaXtO9V0Cc6ZQZ8h8m4UBuLwQ==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.3.tgz",
+      "integrity": "sha512-rXXekcjofVN1LTOSw+u4u9WXVEUvNBVjORW154q/IdmYWy1nMbOU9aNtZB0t8m+FJQ9q91jlr2f9CwwUFdFMRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/validator": "^13.11.8",
-        "libphonenumber-js": "^1.10.53",
-        "validator": "^13.9.0"
+        "@types/validator": "^13.15.3",
+        "libphonenumber-js": "^1.11.1",
+        "validator": "^13.15.20"
       }
     },
     "node_modules/color-convert": {
@@ -3209,6 +3302,54 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/conf": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/conf/-/conf-15.0.2.tgz",
+      "integrity": "sha512-JBSrutapCafTrddF9dH3lc7+T2tBycGF4uPkI4Js+g4vLLEhG6RZcFi3aJd5zntdf5tQxAejJt8dihkoQ/eSJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "atomically": "^2.0.3",
+        "debounce-fn": "^6.0.0",
+        "dot-prop": "^10.0.0",
+        "env-paths": "^3.0.0",
+        "json-schema-typed": "^8.0.1",
+        "semver": "^7.7.2",
+        "uint8array-extras": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/conf/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/conf/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
     },
@@ -3300,6 +3441,22 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/debounce-fn": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-6.0.0.tgz",
+      "integrity": "sha512-rBMW+F2TXryBwB54Q0d8drNEI+TfoS9JpNTAoVpukbWEhjXQq4rySFYLaqXMFXwdv61Zb2OHtj5bviSoimqxRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/debug": {
@@ -3467,6 +3624,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dot-prop": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-10.1.0.tgz",
+      "integrity": "sha512-MVUtAugQMOff5RnBy2d9N31iG0lNwg1qAoAOn7pOK5wf94WIaE3My2p3uwTQuvS2AcqchkcR3bHByjaM0mmi7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -3584,6 +3757,19 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -3660,13 +3846,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/es6-object-assign": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
-      "integrity": "sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.2",
@@ -4218,6 +4397,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fastq": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
@@ -4389,6 +4585,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-intrinsic": {
@@ -4716,11 +4922,15 @@
       }
     },
     "node_modules/inversify": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/inversify/-/inversify-6.0.1.tgz",
-      "integrity": "sha512-B3ex30927698TJENHR++8FfEaJGqoWOgI6ZY5Ht/nLUsFCwHn6akbwtnUAPCgUepAnTpe2qHxhDNjoKLyz6rgQ==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/inversify/-/inversify-6.1.4.tgz",
+      "integrity": "sha512-PbxrZH/gTa1fpPEEGAjJQzK8tKMIp5gRg6EFNJlCtzUcycuNdmhv3uk5P8Itm/RIjgHJO16oQRLo9IHzQN51bA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "@inversifyjs/common": "1.3.3",
+        "@inversifyjs/core": "1.3.4"
+      }
     },
     "node_modules/is-arguments": {
       "version": "1.2.0",
@@ -4877,14 +5087,15 @@
       }
     },
     "node_modules/is-generator-function": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
-      "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bound": "^1.0.3",
-        "get-proto": "^1.0.0",
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
         "has-tostringtag": "^1.0.2",
         "safe-regex-test": "^1.1.0"
       },
@@ -5132,101 +5343,52 @@
       }
     },
     "node_modules/javascript-obfuscator": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/javascript-obfuscator/-/javascript-obfuscator-4.1.1.tgz",
-      "integrity": "sha512-gt+KZpIIrrxXHEQGD8xZrL8mTRwRY0U76/xz/YX0gZdPrSqQhT/c7dYLASlLlecT3r+FxE7je/+C0oLnTDCx4A==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/javascript-obfuscator/-/javascript-obfuscator-4.2.2.tgz",
+      "integrity": "sha512-+7oXAUnFCA6vS0omIGHcWpSr67dUBIF7FKGYSXyzxShSLqM6LBgdugWKFl0XrYtGWyJMGfQR5F4LL85iCefkRA==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@javascript-obfuscator/escodegen": "2.3.0",
+        "@javascript-obfuscator/escodegen": "2.3.1",
         "@javascript-obfuscator/estraverse": "5.4.0",
-        "acorn": "8.8.2",
-        "assert": "2.0.0",
+        "acorn": "8.15.0",
+        "assert": "2.1.0",
         "chalk": "4.1.2",
-        "chance": "1.1.9",
-        "class-validator": "0.14.1",
-        "commander": "10.0.0",
-        "eslint-scope": "7.1.1",
-        "eslint-visitor-keys": "3.3.0",
+        "chance": "1.1.13",
+        "class-validator": "0.14.3",
+        "commander": "12.1.0",
+        "conf": "15.0.2",
+        "eslint-scope": "8.4.0",
+        "eslint-visitor-keys": "4.2.1",
         "fast-deep-equal": "3.1.3",
-        "inversify": "6.0.1",
+        "inversify": "6.1.4",
         "js-string-escape": "1.0.1",
         "md5": "2.3.0",
-        "mkdirp": "2.1.3",
+        "mkdirp": "3.0.1",
         "multimatch": "5.0.0",
-        "opencollective-postinstall": "2.0.3",
         "process": "0.11.10",
-        "reflect-metadata": "0.1.13",
+        "reflect-metadata": "0.2.2",
         "source-map-support": "0.5.21",
         "string-template": "1.0.0",
         "stringz": "2.1.0",
-        "tslib": "2.5.0"
+        "tslib": "2.8.1"
       },
       "bin": {
         "javascript-obfuscator": "bin/javascript-obfuscator"
       },
       "engines": {
-        "node": ">=12.22.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/javascript-obfuscator"
-      }
-    },
-    "node_modules/javascript-obfuscator/node_modules/acorn": {
-      "version": "8.8.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
-      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/javascript-obfuscator/node_modules/commander": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.0.tgz",
-      "integrity": "sha512-zS5PnTI22FIRM6ylNW8G4Ap0IEOyk62fhLSD0+uHRT9McRCLGpkVNvao4bjimpK/GShynyQkFFxHhwMcETmduA==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
-    },
-    "node_modules/javascript-obfuscator/node_modules/eslint-scope": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
-      "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^5.2.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/javascript-obfuscator/node_modules/eslint-visitor-keys": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/javascript-obfuscator/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
-      "dev": true,
-      "license": "0BSD"
     },
     "node_modules/jiti": {
       "version": "1.21.6",
@@ -5365,6 +5527,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -5410,9 +5579,9 @@
       }
     },
     "node_modules/libphonenumber-js": {
-      "version": "1.12.6",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.12.6.tgz",
-      "integrity": "sha512-PJiS4ETaUfCOFLpmtKzAbqZQjCCKVu2OhTV4SVNNE7c2nu/dACvtCqj4L0i/KWNnIgRv7yrILvBj5Lonv5Ncxw==",
+      "version": "1.12.35",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.12.35.tgz",
+      "integrity": "sha512-T/Cz6iLcsZdb5jDncDcUNhSAJ0VlSC9TnsqtBNdpkaAmy24/R1RhErtNWVWBrcUZKs9hSgaVsBkc7HxYnazIfw==",
       "dev": true,
       "license": "MIT"
     },
@@ -5596,6 +5765,19 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/mini-svg-data-uri": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz",
@@ -5633,9 +5815,9 @@
       }
     },
     "node_modules/mkdirp": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-2.1.3.tgz",
-      "integrity": "sha512-sjAkg21peAG9HS+Dkx7hlG9Ztx7HLeKnvB3NQRcu/mltCVmvkF0pisbiTSfDVYTT86XEfZrTUosLdZLStquZUw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -5891,16 +6073,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/opencollective-postinstall": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
-      "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "opencollective-postinstall": "index.js"
       }
     },
     "node_modules/optionator": {
@@ -6430,9 +6602,9 @@
       }
     },
     "node_modules/reflect-metadata": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
-      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -6462,6 +6634,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -6651,9 +6833,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -7015,6 +7197,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/stubborn-fs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-2.0.0.tgz",
+      "integrity": "sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stubborn-utils": "^1.0.1"
+      }
+    },
+    "node_modules/stubborn-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stubborn-utils/-/stubborn-utils-1.0.2.tgz",
+      "integrity": "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/sucrase": {
       "version": "3.35.0",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
@@ -7070,6 +7269,19 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/tailwindcss": {
       "version": "3.4.10",
@@ -7368,19 +7580,20 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
-      "devOptional": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
+    "node_modules/type-fest": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.4.1.tgz",
+      "integrity": "sha512-xygQcmneDyzsEuKZrFbRMne5HDqMs++aFzefrJTgEIKjQ3rekM+RPfFCVq2Gp1VIDqddoYeppCj4Pcb+RZW0GQ==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typescript-eslint": {
@@ -7412,6 +7625,19 @@
       "integrity": "sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.0",
@@ -8180,14 +8406,21 @@
         }
       }
     },
-    "node_modules/vite-plugin-obfuscator": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/vite-plugin-obfuscator/-/vite-plugin-obfuscator-1.0.5.tgz",
-      "integrity": "sha512-5kflM0I3dIpFYIRmPHtdr5Y54Zrtzrhzm6eQMdIh8kcq3Mde/Fr8E3wR4Z2kdtZYSP3DjqeR4LfXRAIsNBGoFg==",
+    "node_modules/vite-plugin-bundle-obfuscator": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-bundle-obfuscator/-/vite-plugin-bundle-obfuscator-1.10.0.tgz",
+      "integrity": "sha512-a68gGYcLgGu2/aBjd7m2KVtHq6uoGDunU6psXNBQh+47xW55IUDKw2BGOttMFG3azApwqKdtoWsrefmyyO/+1Q==",
       "dev": true,
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
-        "javascript-obfuscator": "^4.0.0"
+        "@jridgewell/remapping": "^2.3.5",
+        "javascript-obfuscator": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/vite-plugin-pages": {
@@ -9098,6 +9331,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/when-exit": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.5.tgz",
+      "integrity": "sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "tailwindcss": "^3.4.10",
     "terser": "^5.39.0",
     "vite": "^7.3.1",
-    "vite-plugin-obfuscator": "^1.0.5",
+    "vite-plugin-bundle-obfuscator": "^1.10.0",
     "vite-plugin-pages": "^0.32.3",
     "vitest": "^3.0.9",
     "vue-eslint-parser": "^10.1.1"

--- a/src/__tests__/PortfolioOfPages.spec.js
+++ b/src/__tests__/PortfolioOfPages.spec.js
@@ -40,24 +40,18 @@ describe('PortfolioOfPages', () => {
       props: mockProps
     })
     const carousel = wrapper.findComponent({ name: 'Carousel' })
-    
-    expect(carousel.props('projects')).toEqual([
-      {
-        imagesrc: expect.any(String),
-        imageAlt: 'Descripcion',
-        link: '#'
-      },
-      {
-        imagesrc: expect.any(String),
-        imageAlt: 'Descripcion',
-        link: '#'
-      },
-      {
-        imagesrc: expect.any(String),
-        imageAlt: 'Descripcion',
-        link: '#'
-      }
-    ])
+    const projects = carousel.props('projects')
+
+    // Verify projects array has items with expected structure
+    expect(projects.length).toBeGreaterThan(0)
+    projects.forEach(project => {
+      expect(project).toHaveProperty('imagesrc')
+      expect(project).toHaveProperty('imageAlt')
+      expect(project).toHaveProperty('link')
+      expect(typeof project.imagesrc).toBe('string')
+      expect(typeof project.imageAlt).toBe('string')
+      expect(typeof project.link).toBe('string')
+    })
   })
 
   it('has correct section layout and classes', () => {

--- a/src/__tests__/portfolio/PortfolioCard.spec.js
+++ b/src/__tests__/portfolio/PortfolioCard.spec.js
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import PortfolioCard from '../../components/portfolio/PortfolioCard.vue'
+
+const mockProject = {
+  id: '1',
+  slug: 'test-project',
+  title: 'Test Project',
+  shortDescription: 'A test project description',
+  category: 'landing-page',
+  size: 'major',
+  featured: true,
+  thumbnail: {
+    src: '/test-image.jpg',
+    alt: 'Test image'
+  },
+  heroImage: {
+    src: '/test-hero.jpg',
+    alt: 'Test hero'
+  },
+  technologies: ['Vue', 'Tailwind', 'Node.js', 'PostgreSQL'],
+  completedDate: '2025-01-01',
+  order: 1
+}
+
+describe('PortfolioCard', () => {
+  it('mounts properly', () => {
+    const wrapper = mount(PortfolioCard, {
+      props: { project: mockProject }
+    })
+    expect(wrapper.exists()).toBe(true)
+  })
+
+  it('renders project title', () => {
+    const wrapper = mount(PortfolioCard, {
+      props: { project: mockProject }
+    })
+    const title = wrapper.find('.card-title')
+    expect(title.text()).toBe(mockProject.title)
+  })
+
+  it('renders project description', () => {
+    const wrapper = mount(PortfolioCard, {
+      props: { project: mockProject }
+    })
+    const description = wrapper.find('.card-description')
+    expect(description.text()).toBe(mockProject.shortDescription)
+  })
+
+  it('renders category label', () => {
+    const wrapper = mount(PortfolioCard, {
+      props: { project: mockProject }
+    })
+    const category = wrapper.find('.card-category')
+    expect(category.exists()).toBe(true)
+    expect(category.text()).toBe('Landing Page')
+  })
+
+  it('renders thumbnail image', () => {
+    const wrapper = mount(PortfolioCard, {
+      props: { project: mockProject }
+    })
+    const img = wrapper.find('.card-image')
+    expect(img.attributes('src')).toBe(mockProject.thumbnail.src)
+    expect(img.attributes('alt')).toBe(mockProject.thumbnail.alt)
+  })
+
+  it('displays max 3 technologies', () => {
+    const wrapper = mount(PortfolioCard, {
+      props: { project: mockProject }
+    })
+    const techBadges = wrapper.findAll('.tech-badge')
+
+    // 3 visible + 1 "+1" badge = 4 total
+    expect(techBadges.length).toBe(4)
+    expect(techBadges[3].text()).toBe('+1')
+  })
+
+  it('emits select event on click', async () => {
+    const wrapper = mount(PortfolioCard, {
+      props: { project: mockProject }
+    })
+
+    await wrapper.find('.portfolio-card').trigger('click')
+    expect(wrapper.emitted('select')).toBeTruthy()
+    expect(wrapper.emitted('select')[0]).toEqual([mockProject])
+  })
+
+  it('emits select event on enter key', async () => {
+    const wrapper = mount(PortfolioCard, {
+      props: { project: mockProject }
+    })
+
+    await wrapper.find('.portfolio-card').trigger('keydown.enter')
+    expect(wrapper.emitted('select')).toBeTruthy()
+  })
+
+  it('emits select event on space key', async () => {
+    const wrapper = mount(PortfolioCard, {
+      props: { project: mockProject }
+    })
+
+    await wrapper.find('.portfolio-card').trigger('keydown.space')
+    expect(wrapper.emitted('select')).toBeTruthy()
+  })
+
+  it('has proper accessibility attributes', () => {
+    const wrapper = mount(PortfolioCard, {
+      props: { project: mockProject }
+    })
+    const card = wrapper.find('.portfolio-card')
+
+    expect(card.attributes('role')).toBe('button')
+    expect(card.attributes('tabindex')).toBe('0')
+  })
+})

--- a/src/__tests__/portfolio/PortfolioFilter.spec.js
+++ b/src/__tests__/portfolio/PortfolioFilter.spec.js
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import PortfolioFilter from '../../components/portfolio/PortfolioFilter.vue'
+
+const mockCategories = ['landing-page', 'e-commerce', 'corporate']
+
+describe('PortfolioFilter', () => {
+  it('mounts properly', () => {
+    const wrapper = mount(PortfolioFilter, {
+      props: {
+        categories: mockCategories,
+        activeCategory: null
+      }
+    })
+    expect(wrapper.exists()).toBe(true)
+  })
+
+  it('renders "Todos" button', () => {
+    const wrapper = mount(PortfolioFilter, {
+      props: {
+        categories: mockCategories,
+        activeCategory: null
+      }
+    })
+
+    const buttons = wrapper.findAll('.filter-button')
+    expect(buttons[0].text()).toBe('Todos')
+  })
+
+  it('renders button for each category', () => {
+    const wrapper = mount(PortfolioFilter, {
+      props: {
+        categories: mockCategories,
+        activeCategory: null
+      }
+    })
+
+    // +1 for "Todos" button
+    const buttons = wrapper.findAll('.filter-button')
+    expect(buttons.length).toBe(mockCategories.length + 1)
+  })
+
+  it('shows "Todos" as active when no category selected', () => {
+    const wrapper = mount(PortfolioFilter, {
+      props: {
+        categories: mockCategories,
+        activeCategory: null
+      }
+    })
+
+    const todosButton = wrapper.findAll('.filter-button')[0]
+    expect(todosButton.classes()).toContain('filter-button--active')
+  })
+
+  it('shows category as active when selected', () => {
+    const wrapper = mount(PortfolioFilter, {
+      props: {
+        categories: mockCategories,
+        activeCategory: 'landing-page'
+      }
+    })
+
+    const buttons = wrapper.findAll('.filter-button')
+    const todosButton = buttons[0]
+    const landingButton = buttons[1] // First category after "Todos"
+
+    expect(todosButton.classes()).not.toContain('filter-button--active')
+    expect(landingButton.classes()).toContain('filter-button--active')
+  })
+
+  it('emits update:activeCategory with null when clicking Todos', async () => {
+    const wrapper = mount(PortfolioFilter, {
+      props: {
+        categories: mockCategories,
+        activeCategory: 'landing-page'
+      }
+    })
+
+    const todosButton = wrapper.findAll('.filter-button')[0]
+    await todosButton.trigger('click')
+
+    expect(wrapper.emitted('update:activeCategory')).toBeTruthy()
+    expect(wrapper.emitted('update:activeCategory')[0]).toEqual([null])
+  })
+
+  it('emits update:activeCategory with category when clicking category', async () => {
+    const wrapper = mount(PortfolioFilter, {
+      props: {
+        categories: mockCategories,
+        activeCategory: null
+      }
+    })
+
+    const categoryButton = wrapper.findAll('.filter-button')[1]
+    await categoryButton.trigger('click')
+
+    expect(wrapper.emitted('update:activeCategory')).toBeTruthy()
+    expect(wrapper.emitted('update:activeCategory')[0]).toEqual(['landing-page'])
+  })
+
+  it('has proper accessibility attributes', () => {
+    const wrapper = mount(PortfolioFilter, {
+      props: {
+        categories: mockCategories,
+        activeCategory: null
+      }
+    })
+
+    const container = wrapper.find('.filter-container')
+    expect(container.attributes('role')).toBe('tablist')
+
+    const buttons = wrapper.findAll('.filter-button')
+    buttons.forEach(button => {
+      expect(button.attributes('role')).toBe('tab')
+      expect(button.attributes('aria-selected')).toBeDefined()
+    })
+  })
+
+  it('displays category labels in Spanish', () => {
+    const wrapper = mount(PortfolioFilter, {
+      props: {
+        categories: mockCategories,
+        activeCategory: null
+      }
+    })
+
+    const buttons = wrapper.findAll('.filter-button')
+    expect(buttons[1].text()).toBe('Landing Page')
+    expect(buttons[2].text()).toBe('E-commerce')
+    expect(buttons[3].text()).toBe('Corporativo')
+  })
+})

--- a/src/__tests__/portfolio/projects.spec.js
+++ b/src/__tests__/portfolio/projects.spec.js
@@ -1,0 +1,212 @@
+import { describe, it, expect } from 'vitest'
+import {
+  getAllProjects,
+  getFeaturedProjects,
+  getProjectBySlug,
+  getProjectById,
+  getProjectsByCategory,
+  getProjectsBySize,
+  getAvailableCategories,
+  toLegacyProject,
+  getFeaturedProjectsLegacy,
+  getCategoryLabel,
+  categoryLabels
+} from '../../data/projects'
+
+describe('Projects Data Layer', () => {
+  describe('getAllProjects', () => {
+    it('returns all projects sorted by order', () => {
+      const projects = getAllProjects()
+      expect(projects.length).toBeGreaterThan(0)
+
+      // Verify sorted by order
+      for (let i = 1; i < projects.length; i++) {
+        expect(projects[i].order).toBeGreaterThanOrEqual(projects[i - 1].order)
+      }
+    })
+
+    it('returns projects with required fields', () => {
+      const projects = getAllProjects()
+      projects.forEach(project => {
+        expect(project).toHaveProperty('id')
+        expect(project).toHaveProperty('slug')
+        expect(project).toHaveProperty('title')
+        expect(project).toHaveProperty('shortDescription')
+        expect(project).toHaveProperty('category')
+        expect(project).toHaveProperty('size')
+        expect(project).toHaveProperty('featured')
+        expect(project).toHaveProperty('thumbnail')
+        expect(project).toHaveProperty('heroImage')
+        expect(project).toHaveProperty('technologies')
+        expect(project).toHaveProperty('completedDate')
+        expect(project).toHaveProperty('order')
+      })
+    })
+  })
+
+  describe('getFeaturedProjects', () => {
+    it('returns only featured projects', () => {
+      const featured = getFeaturedProjects()
+      featured.forEach(project => {
+        expect(project.featured).toBe(true)
+      })
+    })
+
+    it('returns projects sorted by order', () => {
+      const featured = getFeaturedProjects()
+      for (let i = 1; i < featured.length; i++) {
+        expect(featured[i].order).toBeGreaterThanOrEqual(featured[i - 1].order)
+      }
+    })
+  })
+
+  describe('getProjectBySlug', () => {
+    it('finds project by slug', () => {
+      const allProjects = getAllProjects()
+      const testSlug = allProjects[0].slug
+      const project = getProjectBySlug(testSlug)
+
+      expect(project).toBeDefined()
+      expect(project.slug).toBe(testSlug)
+    })
+
+    it('returns undefined for non-existent slug', () => {
+      const project = getProjectBySlug('non-existent-slug')
+      expect(project).toBeUndefined()
+    })
+  })
+
+  describe('getProjectById', () => {
+    it('finds project by id', () => {
+      const allProjects = getAllProjects()
+      const testId = allProjects[0].id
+      const project = getProjectById(testId)
+
+      expect(project).toBeDefined()
+      expect(project.id).toBe(testId)
+    })
+
+    it('returns undefined for non-existent id', () => {
+      const project = getProjectById('non-existent-id')
+      expect(project).toBeUndefined()
+    })
+  })
+
+  describe('getProjectsByCategory', () => {
+    it('filters projects by category', () => {
+      const categories = getAvailableCategories()
+      if (categories.length > 0) {
+        const testCategory = categories[0]
+        const projects = getProjectsByCategory(testCategory)
+
+        expect(projects.length).toBeGreaterThan(0)
+        projects.forEach(project => {
+          expect(project.category).toBe(testCategory)
+        })
+      }
+    })
+
+    it('returns empty array for unused category', () => {
+      // Find a category that might not be used
+      const allProjects = getAllProjects()
+      const usedCategories = new Set(allProjects.map(p => p.category))
+
+      // Test with portfolio category if not used
+      if (!usedCategories.has('portfolio')) {
+        const projects = getProjectsByCategory('portfolio')
+        expect(projects).toEqual([])
+      }
+    })
+  })
+
+  describe('getProjectsBySize', () => {
+    it('filters projects by major size', () => {
+      const majorProjects = getProjectsBySize('major')
+      majorProjects.forEach(project => {
+        expect(project.size).toBe('major')
+      })
+    })
+
+    it('filters projects by simple size', () => {
+      const simpleProjects = getProjectsBySize('simple')
+      simpleProjects.forEach(project => {
+        expect(project.size).toBe('simple')
+      })
+    })
+  })
+
+  describe('getAvailableCategories', () => {
+    it('returns unique categories from projects', () => {
+      const categories = getAvailableCategories()
+      const uniqueCategories = new Set(categories)
+
+      expect(categories.length).toBe(uniqueCategories.size)
+    })
+
+    it('returns valid category types', () => {
+      const validCategories = ['landing-page', 'e-commerce', 'corporate', 'portfolio', 'custom']
+      const categories = getAvailableCategories()
+
+      categories.forEach(category => {
+        expect(validCategories).toContain(category)
+      })
+    })
+  })
+
+  describe('toLegacyProject', () => {
+    it('converts project to legacy format', () => {
+      const project = getAllProjects()[0]
+      const legacy = toLegacyProject(project)
+
+      expect(legacy).toHaveProperty('imagesrc')
+      expect(legacy).toHaveProperty('imageAlt')
+      expect(legacy).toHaveProperty('link')
+      expect(legacy.imagesrc).toBe(project.thumbnail.src)
+      expect(legacy.imageAlt).toBe(project.thumbnail.alt)
+    })
+
+    it('uses liveUrl or defaults to #', () => {
+      const project = getAllProjects()[0]
+      const legacy = toLegacyProject(project)
+
+      if (project.liveUrl) {
+        expect(legacy.link).toBe(project.liveUrl)
+      } else {
+        expect(legacy.link).toBe('#')
+      }
+    })
+  })
+
+  describe('getFeaturedProjectsLegacy', () => {
+    it('returns featured projects in legacy format', () => {
+      const legacy = getFeaturedProjectsLegacy()
+
+      legacy.forEach(project => {
+        expect(project).toHaveProperty('imagesrc')
+        expect(project).toHaveProperty('imageAlt')
+        expect(project).toHaveProperty('link')
+      })
+    })
+  })
+
+  describe('getCategoryLabel', () => {
+    it('returns Spanish label for each category', () => {
+      expect(getCategoryLabel('landing-page')).toBe('Landing Page')
+      expect(getCategoryLabel('e-commerce')).toBe('E-commerce')
+      expect(getCategoryLabel('corporate')).toBe('Corporativo')
+      expect(getCategoryLabel('portfolio')).toBe('Portafolio')
+      expect(getCategoryLabel('custom')).toBe('Personalizado')
+    })
+  })
+
+  describe('categoryLabels', () => {
+    it('has labels for all category types', () => {
+      const expectedCategories = ['landing-page', 'e-commerce', 'corporate', 'portfolio', 'custom']
+
+      expectedCategories.forEach(category => {
+        expect(categoryLabels[category]).toBeDefined()
+        expect(typeof categoryLabels[category]).toBe('string')
+      })
+    })
+  })
+})

--- a/src/components/Carousel.vue
+++ b/src/components/Carousel.vue
@@ -62,10 +62,10 @@
 
 <script lang="ts" setup>
 import { ref } from 'vue'
-import { Project } from '../types/project'
+import { LegacyProject } from '../types/project'
 
 const props = defineProps<{
-  projects: Project[]
+  projects: LegacyProject[]
 }>()
 
 const currentIndex = ref(0)

--- a/src/components/PortfolioOfPages.vue
+++ b/src/components/PortfolioOfPages.vue
@@ -4,48 +4,42 @@
       {{ title }}
     </h2>
 
-    <Carousel :projects="projects" />
+    <Carousel :projects="legacyProjects" />
   </section>
 </template>
 
-<script lang="ts">
-import Carousel from './Carousel.vue';
-import mockup from '../assets/mockup.png';
+<script lang="ts" setup>
+import { computed } from 'vue'
+import Carousel from './Carousel.vue'
+import { getFeaturedProjects, toLegacyProject } from '../data/projects'
+import mockup from '../assets/mockup.png'
 
-export default {
-  name: 'PortfolioOfPages',
-  components: {
-    Carousel,
-  },
-  props: {
-    title: {
-      type: String,
-      required: true,
-    },
-  },
-  data() {
-    return {
-      projects: [
-        {
-          imagesrc: mockup,
-          imageAlt: 'Descripcion',
-          link: '#',
-        },
-        {
+defineProps<{
+  title: string
+}>()
 
-          imagesrc: mockup,
-          imageAlt: 'Descripcion',
-          link: '#',
-        },
-        {
-          imagesrc: mockup,
-          imageAlt: 'Descripcion',
-          link: '#',
-        },
-      ],
-    };
-  },
-};
+// Get featured projects from real data, falling back to mockup if images aren't available
+const legacyProjects = computed(() => {
+  const featured = getFeaturedProjects()
+
+  // If we have real projects, convert them to legacy format
+  if (featured.length > 0) {
+    return featured.map(project => ({
+      ...toLegacyProject(project),
+      // Use mockup as fallback for placeholder images
+      imagesrc: project.thumbnail.src.startsWith('/portfolio/placeholder')
+        ? mockup
+        : project.thumbnail.src
+    }))
+  }
+
+  // Fallback to original mock data
+  return [
+    { imagesrc: mockup, imageAlt: 'Descripcion', link: '#' },
+    { imagesrc: mockup, imageAlt: 'Descripcion', link: '#' },
+    { imagesrc: mockup, imageAlt: 'Descripcion', link: '#' },
+  ]
+})
 </script>
 
 <style scoped>

--- a/src/components/portfolio/PortfolioCard.vue
+++ b/src/components/portfolio/PortfolioCard.vue
@@ -1,0 +1,140 @@
+<template>
+  <article
+    class="portfolio-card"
+    :class="{ 'portfolio-card--featured': featured }"
+    @click="$emit('select', project)"
+    role="button"
+    tabindex="0"
+    @keydown.enter="$emit('select', project)"
+    @keydown.space.prevent="$emit('select', project)"
+  >
+    <div class="card-image-container">
+      <img
+        :src="project.thumbnail.src"
+        :alt="project.thumbnail.alt"
+        class="card-image"
+        loading="lazy"
+      />
+      <div class="card-overlay">
+        <span class="card-view-text">Ver proyecto</span>
+      </div>
+    </div>
+
+    <div class="card-content">
+      <span class="card-category">{{ categoryLabel }}</span>
+      <h3 class="card-title">{{ project.title }}</h3>
+      <p class="card-description">{{ project.shortDescription }}</p>
+
+      <div class="card-technologies">
+        <span
+          v-for="tech in displayedTechnologies"
+          :key="tech"
+          class="tech-badge"
+        >
+          {{ tech }}
+        </span>
+        <span v-if="remainingTechCount > 0" class="tech-badge tech-badge--more">
+          +{{ remainingTechCount }}
+        </span>
+      </div>
+    </div>
+  </article>
+</template>
+
+<script lang="ts" setup>
+import { computed } from 'vue'
+import type { Project } from '../../types/project'
+import { getCategoryLabel } from '../../data/projects'
+
+const props = defineProps<{
+  project: Project
+  featured?: boolean
+}>()
+
+defineEmits<{
+  select: [project: Project]
+}>()
+
+const categoryLabel = computed(() => getCategoryLabel(props.project.category))
+
+const maxTechnologies = 3
+const displayedTechnologies = computed(() =>
+  props.project.technologies.slice(0, maxTechnologies)
+)
+const remainingTechCount = computed(() =>
+  Math.max(0, props.project.technologies.length - maxTechnologies)
+)
+</script>
+
+<style scoped>
+.portfolio-card {
+  @apply rounded-2xl shadow-3xl overflow-hidden cursor-pointer;
+  @apply transition-all duration-300 ease-out;
+  @apply hover:scale-[1.02] hover:shadow-lg;
+  @apply focus:outline-none focus:ring-2 focus:ring-lightGreen focus:ring-offset-2;
+  @apply bg-white;
+}
+
+.card-image-container {
+  @apply relative overflow-hidden;
+  aspect-ratio: 16 / 9;
+}
+
+.card-image {
+  @apply w-full h-full object-cover transition-transform duration-500;
+}
+
+.portfolio-card:hover .card-image {
+  @apply scale-110;
+}
+
+.card-overlay {
+  @apply absolute inset-0 bg-black/0 transition-all duration-300;
+  @apply flex items-center justify-center;
+}
+
+.portfolio-card:hover .card-overlay {
+  @apply bg-black/40;
+}
+
+.card-view-text {
+  @apply text-white text-lg font-medium opacity-0 transform translate-y-4;
+  @apply transition-all duration-300;
+}
+
+.portfolio-card:hover .card-view-text {
+  @apply opacity-100 translate-y-0;
+}
+
+.card-content {
+  @apply p-5;
+}
+
+.card-category {
+  @apply inline-block text-xs uppercase tracking-wider text-lightGreen font-medium mb-2;
+}
+
+.card-title {
+  @apply text-xl font-bold text-txtcolor mb-2 lowercase;
+}
+
+.card-description {
+  @apply text-sm text-gray mb-4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.card-technologies {
+  @apply flex flex-wrap gap-2;
+}
+
+.tech-badge {
+  @apply text-xs px-3 py-1 rounded-full bg-snowGray text-gray;
+}
+
+.tech-badge--more {
+  @apply bg-lightGreen/10 text-lightGreen;
+}
+</style>

--- a/src/components/portfolio/PortfolioDetailModal.vue
+++ b/src/components/portfolio/PortfolioDetailModal.vue
@@ -1,0 +1,291 @@
+<template>
+  <Teleport to="body">
+    <Transition name="modal">
+      <div
+        v-if="project"
+        class="modal-backdrop"
+        @click.self="$emit('close')"
+        role="dialog"
+        aria-modal="true"
+        :aria-labelledby="'modal-title-' + project.id"
+      >
+        <div class="modal-container" ref="modalContainer">
+          <!-- Close Button -->
+          <button
+            class="modal-close"
+            @click="$emit('close')"
+            aria-label="Cerrar modal"
+          >
+            <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+
+          <!-- Modal Content -->
+          <div class="modal-content">
+            <!-- Hero Image -->
+            <div class="modal-hero">
+              <img
+                :src="project.heroImage.src"
+                :alt="project.heroImage.alt"
+                class="modal-hero-image"
+              />
+            </div>
+
+            <!-- Project Info -->
+            <div class="modal-body">
+              <div class="modal-header">
+                <span class="modal-category">{{ categoryLabel }}</span>
+                <h2
+                  :id="'modal-title-' + project.id"
+                  class="modal-title"
+                >
+                  {{ project.title }}
+                </h2>
+                <p v-if="project.clientName" class="modal-client">
+                  Cliente: {{ project.clientName }}
+                </p>
+              </div>
+
+              <!-- Description -->
+              <div class="modal-description">
+                <p>{{ project.fullDescription || project.shortDescription }}</p>
+              </div>
+
+              <!-- Technologies -->
+              <div class="modal-section">
+                <h3 class="modal-section-title">Tecnologias</h3>
+                <div class="modal-technologies">
+                  <span
+                    v-for="tech in project.technologies"
+                    :key="tech"
+                    class="tech-badge"
+                  >
+                    {{ tech }}
+                  </span>
+                </div>
+              </div>
+
+              <!-- Gallery -->
+              <div v-if="project.gallery && project.gallery.length > 0" class="modal-section">
+                <h3 class="modal-section-title">Galeria</h3>
+                <ProjectGallery :images="project.gallery" />
+              </div>
+
+              <!-- Testimonial -->
+              <div v-if="project.testimonial" class="modal-section">
+                <h3 class="modal-section-title">Testimonio</h3>
+                <ProjectTestimonial :testimonial="project.testimonial" />
+              </div>
+
+              <!-- CTA -->
+              <div class="modal-cta">
+                <a
+                  v-if="project.liveUrl && project.liveUrl !== '#'"
+                  :href="project.liveUrl"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="cta-button cta-button--primary"
+                >
+                  Ver sitio web
+                </a>
+                <router-link
+                  to="/contact"
+                  class="cta-button cta-button--secondary"
+                  @click="$emit('close')"
+                >
+                  Solicitar proyecto similar
+                </router-link>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script lang="ts" setup>
+import { computed, watch, ref, onMounted, onUnmounted } from 'vue'
+import type { Project } from '../../types/project'
+import { getCategoryLabel } from '../../data/projects'
+import ProjectGallery from './ProjectGallery.vue'
+import ProjectTestimonial from './ProjectTestimonial.vue'
+
+const props = defineProps<{
+  project: Project | null
+}>()
+
+const emit = defineEmits<{
+  close: []
+}>()
+
+const modalContainer = ref<HTMLElement | null>(null)
+
+const categoryLabel = computed(() =>
+  props.project ? getCategoryLabel(props.project.category) : ''
+)
+
+// Handle Escape key
+const handleKeydown = (e: KeyboardEvent) => {
+  if (e.key === 'Escape' && props.project) {
+    emit('close')
+  }
+}
+
+// Lock body scroll when modal is open
+watch(() => props.project, (newVal) => {
+  if (newVal) {
+    document.body.style.overflow = 'hidden'
+  } else {
+    document.body.style.overflow = ''
+  }
+})
+
+onMounted(() => {
+  document.addEventListener('keydown', handleKeydown)
+})
+
+onUnmounted(() => {
+  document.removeEventListener('keydown', handleKeydown)
+  document.body.style.overflow = ''
+})
+</script>
+
+<style scoped>
+.modal-backdrop {
+  @apply fixed inset-0 z-50 bg-black/60 backdrop-blur-sm;
+  @apply flex items-start justify-center;
+  @apply overflow-y-auto py-8 px-4;
+}
+
+.modal-container {
+  @apply relative bg-white rounded-2xl shadow-2xl;
+  @apply w-full max-w-3xl;
+  @apply my-auto;
+}
+
+.modal-close {
+  @apply absolute top-4 right-4 z-10;
+  @apply w-10 h-10 rounded-full bg-white/90 shadow-lg;
+  @apply flex items-center justify-center;
+  @apply transition-all duration-300;
+  @apply hover:bg-white hover:scale-110;
+  @apply focus:outline-none focus:ring-2 focus:ring-lightGreen;
+}
+
+.modal-content {
+  @apply overflow-hidden rounded-2xl;
+}
+
+.modal-hero {
+  @apply w-full bg-snowGray;
+  aspect-ratio: 16 / 9;
+}
+
+.modal-hero-image {
+  @apply w-full h-full object-cover;
+}
+
+.modal-body {
+  @apply p-6;
+}
+
+@media (min-width: 768px) {
+  .modal-body {
+    padding: 2rem;
+  }
+}
+
+.modal-header {
+  @apply mb-6;
+}
+
+.modal-category {
+  @apply inline-block text-xs uppercase tracking-wider text-lightGreen font-medium mb-2;
+}
+
+.modal-title {
+  @apply text-3xl font-bold text-txtcolor lowercase;
+}
+
+@media (min-width: 768px) {
+  .modal-title {
+    font-size: 2.25rem;
+    line-height: 2.5rem;
+  }
+}
+
+.modal-client {
+  @apply text-gray mt-2;
+}
+
+.modal-description {
+  @apply text-txtcolor leading-relaxed mb-6;
+}
+
+.modal-section {
+  @apply mb-6;
+}
+
+.modal-section-title {
+  @apply text-lg font-semibold text-txtcolor mb-3 lowercase;
+}
+
+.modal-technologies {
+  @apply flex flex-wrap gap-2;
+}
+
+.tech-badge {
+  @apply text-sm px-4 py-1.5 rounded-full bg-snowGray text-gray;
+}
+
+.modal-cta {
+  @apply flex flex-col gap-3 pt-4 border-t border-snowGray;
+}
+
+@media (min-width: 640px) {
+  .modal-cta {
+    flex-direction: row;
+  }
+}
+
+.cta-button {
+  @apply px-6 py-3 rounded-full font-medium text-center;
+  @apply transition-all duration-300;
+  @apply focus:outline-none focus:ring-2 focus:ring-offset-2;
+}
+
+.cta-button--primary {
+  @apply bg-lightGreen text-white;
+  @apply hover:bg-lightGreen/90 hover:shadow-lg;
+  @apply focus:ring-lightGreen;
+}
+
+.cta-button--secondary {
+  @apply bg-snowGray text-txtcolor;
+  @apply hover:bg-gray/10;
+  @apply focus:ring-gray;
+}
+
+/* Modal Transition */
+.modal-enter-active,
+.modal-leave-active {
+  @apply transition-all duration-300;
+}
+
+.modal-enter-from,
+.modal-leave-to {
+  @apply opacity-0;
+}
+
+.modal-enter-from .modal-container,
+.modal-leave-to .modal-container {
+  @apply scale-95 opacity-0;
+}
+
+.modal-enter-active .modal-container,
+.modal-leave-active .modal-container {
+  @apply transition-all duration-300;
+}
+</style>

--- a/src/components/portfolio/PortfolioFilter.vue
+++ b/src/components/portfolio/PortfolioFilter.vue
@@ -1,0 +1,58 @@
+<template>
+  <div class="filter-container" role="tablist" aria-label="Filtrar proyectos por categoria">
+    <button
+      class="filter-button"
+      :class="{ 'filter-button--active': !activeCategory }"
+      role="tab"
+      :aria-selected="!activeCategory"
+      @click="$emit('update:activeCategory', null)"
+    >
+      Todos
+    </button>
+    <button
+      v-for="category in categories"
+      :key="category"
+      class="filter-button"
+      :class="{ 'filter-button--active': activeCategory === category }"
+      role="tab"
+      :aria-selected="activeCategory === category"
+      @click="$emit('update:activeCategory', category)"
+    >
+      {{ getCategoryLabel(category) }}
+    </button>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import type { ProjectCategory } from '../../types/project'
+import { getCategoryLabel } from '../../data/projects'
+
+defineProps<{
+  categories: ProjectCategory[]
+  activeCategory: ProjectCategory | null
+}>()
+
+defineEmits<{
+  'update:activeCategory': [category: ProjectCategory | null]
+}>()
+</script>
+
+<style scoped>
+.filter-container {
+  @apply flex flex-wrap gap-2 justify-center;
+}
+
+.filter-button {
+  @apply px-5 py-2 rounded-full text-sm font-medium;
+  @apply transition-all duration-300;
+  @apply border-2 border-transparent;
+  @apply bg-snowGray text-gray;
+  @apply hover:bg-lightGreen/10 hover:text-lightGreen;
+  @apply focus:outline-none focus:ring-2 focus:ring-lightGreen focus:ring-offset-2;
+}
+
+.filter-button--active {
+  @apply bg-lightGreen text-white;
+  @apply hover:bg-lightGreen/90 hover:text-white;
+}
+</style>

--- a/src/components/portfolio/PortfolioGrid.vue
+++ b/src/components/portfolio/PortfolioGrid.vue
@@ -1,0 +1,59 @@
+<template>
+  <div class="portfolio-grid" :class="gridClass">
+    <PortfolioCard
+      v-for="project in projects"
+      :key="project.id"
+      :project="project"
+      :featured="project.featured"
+      @select="$emit('select', $event)"
+    />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { computed } from 'vue'
+import type { Project } from '../../types/project'
+import PortfolioCard from './PortfolioCard.vue'
+
+const props = withDefaults(defineProps<{
+  projects: Project[]
+  columns?: 2 | 3
+}>(), {
+  columns: 3
+})
+
+defineEmits<{
+  select: [project: Project]
+}>()
+
+const gridClass = computed(() => ({
+  'grid-cols-2': props.columns === 2,
+  'grid-cols-3': props.columns === 3
+}))
+</script>
+
+<style scoped>
+.portfolio-grid {
+  @apply grid gap-6 grid-cols-1;
+}
+
+@media (min-width: 768px) {
+  .portfolio-grid {
+    gap: 2rem;
+  }
+
+  .portfolio-grid.grid-cols-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .portfolio-grid.grid-cols-3 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1024px) {
+  .portfolio-grid.grid-cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+</style>

--- a/src/components/portfolio/ProjectGallery.vue
+++ b/src/components/portfolio/ProjectGallery.vue
@@ -1,0 +1,181 @@
+<template>
+  <div class="gallery" v-if="images && images.length > 0">
+    <div
+      class="gallery-container"
+      @touchstart="handleTouchStart"
+      @touchmove="handleTouchMove"
+      @touchend="handleTouchEnd"
+    >
+      <div
+        class="gallery-track"
+        :style="`transform: translateX(-${currentIndex * 100}%)`"
+      >
+        <div
+          v-for="(image, index) in images"
+          :key="index"
+          class="gallery-slide"
+        >
+          <img
+            :src="image.src"
+            :alt="image.alt"
+            class="gallery-image"
+            loading="lazy"
+          />
+        </div>
+      </div>
+    </div>
+
+    <!-- Navigation Arrows -->
+    <button
+      v-if="images.length > 1"
+      @click="prevSlide"
+      class="gallery-arrow gallery-arrow--left"
+      aria-label="Imagen anterior"
+    >
+      <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+      </svg>
+    </button>
+    <button
+      v-if="images.length > 1"
+      @click="nextSlide"
+      class="gallery-arrow gallery-arrow--right"
+      aria-label="Siguiente imagen"
+    >
+      <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+      </svg>
+    </button>
+
+    <!-- Caption -->
+    <p v-if="currentImage?.caption" class="gallery-caption">
+      {{ currentImage.caption }}
+    </p>
+
+    <!-- Dot Indicators -->
+    <div v-if="images.length > 1" class="gallery-dots">
+      <button
+        v-for="(_, index) in images"
+        :key="index"
+        @click="goToSlide(index)"
+        class="gallery-dot"
+        :class="{ 'gallery-dot--active': currentIndex === index }"
+        :aria-label="`Ir a imagen ${index + 1}`"
+      ></button>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref, computed } from 'vue'
+import type { ProjectImage } from '../../types/project'
+
+const props = defineProps<{
+  images: ProjectImage[] | undefined
+}>()
+
+const currentIndex = ref(0)
+const touchStartX = ref(0)
+const touchEndX = ref(0)
+const minSwipeDistance = 50
+
+const currentImage = computed(() =>
+  props.images ? props.images[currentIndex.value] : null
+)
+
+const nextSlide = () => {
+  if (!props.images) return
+  currentIndex.value = (currentIndex.value + 1) % props.images.length
+}
+
+const prevSlide = () => {
+  if (!props.images) return
+  currentIndex.value = (currentIndex.value - 1 + props.images.length) % props.images.length
+}
+
+const goToSlide = (index: number) => {
+  currentIndex.value = index
+}
+
+const handleTouchStart = (e: TouchEvent) => {
+  touchStartX.value = e.touches[0].clientX
+}
+
+const handleTouchMove = (e: TouchEvent) => {
+  touchEndX.value = e.touches[0].clientX
+}
+
+const handleTouchEnd = () => {
+  const swipeDistance = touchStartX.value - touchEndX.value
+
+  if (Math.abs(swipeDistance) > minSwipeDistance) {
+    if (swipeDistance > 0) {
+      nextSlide()
+    } else {
+      prevSlide()
+    }
+  }
+
+  touchStartX.value = 0
+  touchEndX.value = 0
+}
+</script>
+
+<style scoped>
+.gallery {
+  @apply relative;
+}
+
+.gallery-container {
+  @apply relative overflow-hidden rounded-xl;
+}
+
+.gallery-track {
+  @apply flex transition-transform duration-300 ease-out;
+}
+
+.gallery-slide {
+  @apply flex-none w-full;
+}
+
+.gallery-image {
+  @apply w-full h-auto object-cover rounded-xl;
+  max-height: 400px;
+}
+
+.gallery-arrow {
+  @apply absolute top-1/2 -translate-y-1/2;
+  @apply w-10 h-10 rounded-full;
+  @apply bg-white/90 shadow-lg backdrop-blur-sm;
+  @apply flex items-center justify-center;
+  @apply transition-all duration-300;
+  @apply hover:bg-white hover:scale-110;
+  @apply focus:outline-none focus:ring-2 focus:ring-lightGreen;
+}
+
+.gallery-arrow--left {
+  @apply left-2;
+}
+
+.gallery-arrow--right {
+  @apply right-2;
+}
+
+.gallery-caption {
+  @apply text-center text-gray text-sm mt-3;
+}
+
+.gallery-dots {
+  @apply flex justify-center gap-2 mt-4;
+}
+
+.gallery-dot {
+  @apply w-2 h-2 rounded-full bg-gray/30;
+  @apply transition-all duration-300;
+  @apply focus:outline-none focus:ring-2 focus:ring-lightGreen focus:ring-offset-2;
+}
+
+.gallery-dot--active {
+  @apply bg-lightGreen w-6;
+}
+</style>

--- a/src/components/portfolio/ProjectTestimonial.vue
+++ b/src/components/portfolio/ProjectTestimonial.vue
@@ -1,0 +1,51 @@
+<template>
+  <blockquote class="testimonial" v-if="testimonial">
+    <div class="testimonial-quote-icon">
+      <svg class="w-8 h-8 text-lightGreen/30" fill="currentColor" viewBox="0 0 24 24">
+        <path d="M14.017 21v-7.391c0-5.704 3.731-9.57 8.983-10.609l.995 2.151c-2.432.917-3.995 3.638-3.995 5.849h4v10h-9.983zm-14.017 0v-7.391c0-5.704 3.748-9.57 9-10.609l.996 2.151c-2.433.917-3.996 3.638-3.996 5.849h3.983v10h-9.983z" />
+      </svg>
+    </div>
+    <p class="testimonial-text">{{ testimonial.quote }}</p>
+    <footer class="testimonial-footer">
+      <cite class="testimonial-author">{{ testimonial.author }}</cite>
+      <span v-if="testimonial.role" class="testimonial-role">
+        {{ testimonial.role }}<span v-if="testimonial.company">, {{ testimonial.company }}</span>
+      </span>
+    </footer>
+  </blockquote>
+</template>
+
+<script lang="ts" setup>
+import type { ProjectTestimonial } from '../../types/project'
+
+defineProps<{
+  testimonial: ProjectTestimonial | undefined
+}>()
+</script>
+
+<style scoped>
+.testimonial {
+  @apply relative bg-snowGray rounded-2xl p-6 md:p-8;
+}
+
+.testimonial-quote-icon {
+  @apply absolute top-4 left-4 md:top-6 md:left-6;
+}
+
+.testimonial-text {
+  @apply text-txtcolor text-lg md:text-xl italic leading-relaxed;
+  @apply pt-8 md:pt-6;
+}
+
+.testimonial-footer {
+  @apply mt-4 flex flex-col;
+}
+
+.testimonial-author {
+  @apply text-txtcolor font-semibold not-italic;
+}
+
+.testimonial-role {
+  @apply text-gray text-sm;
+}
+</style>

--- a/src/components/portfolio/index.ts
+++ b/src/components/portfolio/index.ts
@@ -1,0 +1,6 @@
+export { default as PortfolioCard } from './PortfolioCard.vue'
+export { default as PortfolioGrid } from './PortfolioGrid.vue'
+export { default as PortfolioFilter } from './PortfolioFilter.vue'
+export { default as PortfolioDetailModal } from './PortfolioDetailModal.vue'
+export { default as ProjectGallery } from './ProjectGallery.vue'
+export { default as ProjectTestimonial } from './ProjectTestimonial.vue'

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -1,0 +1,144 @@
+{
+  "projects": [
+    {
+      "id": "1",
+      "slug": "restaurante-el-dorado",
+      "title": "Restaurante El Dorado",
+      "shortDescription": "Sitio web completo con sistema de reservas y menu digital interactivo",
+      "fullDescription": "Desarrollo integral de presencia digital para restaurante de alta cocina. Incluye sistema de reservas en tiempo real, menu digital con imagenes de alta calidad, integracion con redes sociales y optimizacion SEO local para mayor visibilidad.",
+      "category": "e-commerce",
+      "size": "major",
+      "featured": true,
+      "thumbnail": {
+        "src": "/portfolio/placeholder-restaurant-thumb.jpg",
+        "alt": "Vista previa del sitio web Restaurante El Dorado"
+      },
+      "heroImage": {
+        "src": "/portfolio/placeholder-restaurant-hero.jpg",
+        "alt": "Pagina principal de Restaurante El Dorado"
+      },
+      "gallery": [
+        {
+          "src": "/portfolio/placeholder-restaurant-1.jpg",
+          "alt": "Pagina de menu digital",
+          "caption": "Menu digital interactivo"
+        },
+        {
+          "src": "/portfolio/placeholder-restaurant-2.jpg",
+          "alt": "Sistema de reservas",
+          "caption": "Formulario de reservas"
+        },
+        {
+          "src": "/portfolio/placeholder-restaurant-3.jpg",
+          "alt": "Galeria de platos",
+          "caption": "Galeria fotografica"
+        }
+      ],
+      "technologies": ["Vue 3", "Tailwind CSS", "Node.js", "PostgreSQL"],
+      "clientName": "Restaurante El Dorado",
+      "liveUrl": "#",
+      "testimonial": {
+        "quote": "Argus transformo completamente nuestra presencia digital. Las reservas online han aumentado un 40% desde el lanzamiento.",
+        "author": "Maria Garcia",
+        "role": "Gerente General",
+        "company": "Restaurante El Dorado"
+      },
+      "completedDate": "2025-12-15",
+      "order": 1
+    },
+    {
+      "id": "2",
+      "slug": "consultora-nexus",
+      "title": "Consultora Nexus",
+      "shortDescription": "Portal corporativo con area de clientes y gestion de documentos",
+      "fullDescription": "Plataforma empresarial completa para consultora de negocios. Portal de clientes con acceso seguro, sistema de gestion documental, blog corporativo y formularios de contacto inteligentes con integracion CRM.",
+      "category": "corporate",
+      "size": "major",
+      "featured": true,
+      "thumbnail": {
+        "src": "/portfolio/placeholder-corporate-thumb.jpg",
+        "alt": "Vista previa del sitio web Consultora Nexus"
+      },
+      "heroImage": {
+        "src": "/portfolio/placeholder-corporate-hero.jpg",
+        "alt": "Pagina principal de Consultora Nexus"
+      },
+      "gallery": [
+        {
+          "src": "/portfolio/placeholder-corporate-1.jpg",
+          "alt": "Portal de clientes",
+          "caption": "Area privada de clientes"
+        },
+        {
+          "src": "/portfolio/placeholder-corporate-2.jpg",
+          "alt": "Blog corporativo",
+          "caption": "Seccion de articulos"
+        }
+      ],
+      "technologies": ["Vue 3", "Tailwind CSS", "Express", "MongoDB"],
+      "clientName": "Consultora Nexus",
+      "liveUrl": "#",
+      "testimonial": {
+        "quote": "El portal de clientes ha simplificado enormemente nuestra comunicacion. Muy profesionales.",
+        "author": "Carlos Mendez",
+        "role": "Director",
+        "company": "Consultora Nexus"
+      },
+      "completedDate": "2025-11-20",
+      "order": 2
+    },
+    {
+      "id": "3",
+      "slug": "estudio-legal-martinez",
+      "title": "Estudio Legal Martinez",
+      "shortDescription": "Landing page profesional con formulario de consultas",
+      "fullDescription": "Pagina de presentacion elegante y profesional para estudio juridico. Diseno sobrio que transmite confianza, seccion de areas de practica, perfiles del equipo y formulario de consultas con validacion.",
+      "category": "landing-page",
+      "size": "simple",
+      "featured": false,
+      "thumbnail": {
+        "src": "/portfolio/placeholder-legal-thumb.jpg",
+        "alt": "Vista previa del sitio web Estudio Legal Martinez"
+      },
+      "heroImage": {
+        "src": "/portfolio/placeholder-legal-hero.jpg",
+        "alt": "Pagina principal de Estudio Legal Martinez"
+      },
+      "technologies": ["Vue 3", "Tailwind CSS"],
+      "clientName": "Estudio Legal Martinez",
+      "liveUrl": "#",
+      "completedDate": "2025-10-10",
+      "order": 3
+    },
+    {
+      "id": "4",
+      "slug": "fitness-studio-vive",
+      "title": "Fitness Studio Vive",
+      "shortDescription": "Sitio web con horarios de clases y registro de miembros",
+      "fullDescription": "Landing page dinamica para gimnasio boutique. Calendario de clases actualizable, galeria de instalaciones, testimonios de clientes y formulario de registro para nuevos miembros.",
+      "category": "landing-page",
+      "size": "simple",
+      "featured": false,
+      "thumbnail": {
+        "src": "/portfolio/placeholder-fitness-thumb.jpg",
+        "alt": "Vista previa del sitio web Fitness Studio Vive"
+      },
+      "heroImage": {
+        "src": "/portfolio/placeholder-fitness-hero.jpg",
+        "alt": "Pagina principal de Fitness Studio Vive"
+      },
+      "gallery": [
+        {
+          "src": "/portfolio/placeholder-fitness-1.jpg",
+          "alt": "Horarios de clases",
+          "caption": "Calendario semanal"
+        }
+      ],
+      "technologies": ["Vue 3", "Tailwind CSS", "EmailJS"],
+      "clientName": "Fitness Studio Vive",
+      "liveUrl": "#",
+      "completedDate": "2025-09-25",
+      "order": 4
+    }
+  ]
+}

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -1,0 +1,96 @@
+import type { Project, ProjectCategory, LegacyProject } from '../types/project'
+import projectsData from './projects.json'
+
+const projects: Project[] = projectsData.projects as Project[]
+
+/**
+ * Get all projects sorted by order
+ */
+export function getAllProjects(): Project[] {
+  return [...projects].sort((a, b) => a.order - b.order)
+}
+
+/**
+ * Get featured projects (for homepage hero section)
+ */
+export function getFeaturedProjects(): Project[] {
+  return projects
+    .filter(p => p.featured)
+    .sort((a, b) => a.order - b.order)
+}
+
+/**
+ * Get a single project by its slug
+ */
+export function getProjectBySlug(slug: string): Project | undefined {
+  return projects.find(p => p.slug === slug)
+}
+
+/**
+ * Get a single project by its ID
+ */
+export function getProjectById(id: string): Project | undefined {
+  return projects.find(p => p.id === id)
+}
+
+/**
+ * Get projects filtered by category
+ */
+export function getProjectsByCategory(category: ProjectCategory): Project[] {
+  return projects
+    .filter(p => p.category === category)
+    .sort((a, b) => a.order - b.order)
+}
+
+/**
+ * Get projects filtered by size
+ */
+export function getProjectsBySize(size: 'major' | 'simple'): Project[] {
+  return projects
+    .filter(p => p.size === size)
+    .sort((a, b) => a.order - b.order)
+}
+
+/**
+ * Get all unique categories from existing projects
+ */
+export function getAvailableCategories(): ProjectCategory[] {
+  const categories = new Set(projects.map(p => p.category))
+  return Array.from(categories)
+}
+
+/**
+ * Convert Project to LegacyProject format (for Carousel compatibility)
+ */
+export function toLegacyProject(project: Project): LegacyProject {
+  return {
+    imagesrc: project.thumbnail.src,
+    imageAlt: project.thumbnail.alt,
+    link: project.liveUrl || '#'
+  }
+}
+
+/**
+ * Get featured projects in legacy format for homepage carousel
+ */
+export function getFeaturedProjectsLegacy(): LegacyProject[] {
+  return getFeaturedProjects().map(toLegacyProject)
+}
+
+/**
+ * Category display names in Spanish
+ */
+export const categoryLabels: Record<ProjectCategory, string> = {
+  'landing-page': 'Landing Page',
+  'e-commerce': 'E-commerce',
+  'corporate': 'Corporativo',
+  'portfolio': 'Portafolio',
+  'custom': 'Personalizado'
+}
+
+/**
+ * Get category label in Spanish
+ */
+export function getCategoryLabel(category: ProjectCategory): string {
+  return categoryLabels[category]
+}

--- a/src/pages/Portfolio.vue
+++ b/src/pages/Portfolio.vue
@@ -5,147 +5,163 @@
       subtitle="Descubre nuestros proyectos y el trabajo que hemos realizado"
     />
 
-    <!-- Coming Soon Section -->
-    <section class="coming-soon-section">
-      <div class="coming-soon-content">
-        <!-- Animated Icon -->
-        <div class="icon-container">
-          <svg
-            class="construction-icon"
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="1.5"
-              d="M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z"
-            />
-          </svg>
+    <!-- Featured Projects Section -->
+    <section class="featured-section" v-if="featuredProjects.length > 0">
+      <div class="section-container">
+        <h2 class="section-title">proyectos destacados</h2>
+        <PortfolioGrid
+          :projects="featuredProjects"
+          :columns="2"
+          @select="openProjectModal"
+        />
+      </div>
+    </section>
+
+    <!-- All Projects Section -->
+    <section class="projects-section">
+      <div class="section-container">
+        <!-- Filter Bar -->
+        <div class="filter-bar">
+          <PortfolioFilter
+            :categories="availableCategories"
+            :activeCategory="activeCategory"
+            @update:activeCategory="activeCategory = $event"
+          />
         </div>
 
-        <h2 class="coming-soon-title">Proximamente</h2>
-        <p class="coming-soon-text">
-          Estamos preparando algo increíble para mostrarte. Nuestro portafolio
-          estará disponible muy pronto con todos nuestros proyectos destacados.
-        </p>
+        <!-- Projects Grid -->
+        <PortfolioGrid
+          :projects="filteredProjects"
+          :columns="3"
+          @select="openProjectModal"
+        />
 
+        <!-- Empty State -->
+        <div v-if="filteredProjects.length === 0" class="empty-state">
+          <p>No hay proyectos en esta categoria.</p>
+          <button
+            @click="activeCategory = null"
+            class="empty-state-button"
+          >
+            Ver todos los proyectos
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <!-- CTA Section -->
+    <section class="cta-section">
+      <div class="cta-container">
+        <h2 class="cta-title">tienes un proyecto en mente?</h2>
+        <p class="cta-text">
+          Estamos listos para convertir tu idea en realidad. Contactanos y hagamos algo increible juntos.
+        </p>
         <router-link to="/contact" class="cta-button">
-          Contáctanos
+          Contactanos
         </router-link>
       </div>
     </section>
 
-    <!-- Placeholder Cards -->
-    <section class="placeholder-section">
-      <h3 class="placeholder-title">Proyectos en preparación</h3>
-      <div class="placeholder-grid">
-        <div
-          v-for="n in 3"
-          :key="n"
-          class="placeholder-card"
-          :style="{ animationDelay: `${n * 150}ms` }"
-        >
-          <div class="placeholder-image"></div>
-          <div class="placeholder-content">
-            <div class="placeholder-line w-3/4"></div>
-            <div class="placeholder-line w-1/2"></div>
-          </div>
-        </div>
-      </div>
-    </section>
+    <!-- Project Detail Modal -->
+    <PortfolioDetailModal
+      :project="selectedProject"
+      @close="closeProjectModal"
+    />
   </div>
 </template>
 
 <script lang="ts" setup>
+import { ref, computed } from 'vue'
 import HeaderBanner from '../components/HeaderBanner.vue'
+import { PortfolioGrid, PortfolioFilter, PortfolioDetailModal } from '../components/portfolio'
+import {
+  getAllProjects,
+  getFeaturedProjects,
+  getAvailableCategories
+} from '../data/projects'
+import type { Project, ProjectCategory } from '../types/project'
+
+const allProjects = getAllProjects()
+const featuredProjects = getFeaturedProjects()
+const availableCategories = getAvailableCategories()
+
+const activeCategory = ref<ProjectCategory | null>(null)
+const selectedProject = ref<Project | null>(null)
+
+const filteredProjects = computed(() => {
+  if (!activeCategory.value) {
+    return allProjects
+  }
+  return allProjects.filter(p => p.category === activeCategory.value)
+})
+
+const openProjectModal = (project: Project) => {
+  selectedProject.value = project
+}
+
+const closeProjectModal = () => {
+  selectedProject.value = null
+}
 </script>
 
 <style scoped>
-.coming-soon-section {
-  @apply py-16 md:py-24 px-4;
+.section-container {
+  @apply max-w-6xl mx-auto px-4;
 }
 
-.coming-soon-content {
-  @apply max-w-2xl mx-auto text-center;
+.section-title {
+  @apply text-3xl md:text-4xl font-bold text-txtcolor text-center mb-10 lowercase;
 }
 
-.icon-container {
-  @apply w-24 h-24 md:w-32 md:h-32 mx-auto mb-8;
-  @apply rounded-full shadow-3xl flex items-center justify-center;
-  @apply bg-snowGray;
+/* Featured Section */
+.featured-section {
+  @apply py-16 md:py-20;
 }
 
-.construction-icon {
-  @apply w-12 h-12 md:w-16 md:h-16 text-lightGreen;
-  animation: float 3s ease-in-out infinite;
+/* Projects Section */
+.projects-section {
+  @apply py-16 md:py-20 bg-snowGray;
 }
 
-.coming-soon-title {
-  @apply text-4xl md:text-5xl lg:text-6xl font-bold text-txtcolor mb-6;
-  @apply tracking-tight lowercase;
+.filter-bar {
+  @apply mb-10;
 }
 
-.coming-soon-text {
-  @apply text-lg md:text-xl text-gray mb-10 max-w-lg mx-auto;
+/* Empty State */
+.empty-state {
+  @apply text-center py-16;
+}
+
+.empty-state p {
+  @apply text-gray text-lg mb-4;
+}
+
+.empty-state-button {
+  @apply text-lightGreen font-medium hover:underline;
+  @apply focus:outline-none focus:ring-2 focus:ring-lightGreen focus:ring-offset-2 rounded;
+}
+
+/* CTA Section */
+.cta-section {
+  @apply py-20 md:py-28;
+}
+
+.cta-container {
+  @apply max-w-2xl mx-auto text-center px-4;
+}
+
+.cta-title {
+  @apply text-4xl md:text-5xl font-bold text-txtcolor mb-6 lowercase;
+}
+
+.cta-text {
+  @apply text-lg text-gray mb-10 max-w-lg mx-auto;
 }
 
 .cta-button {
   @apply inline-block px-10 py-3 bg-lightGreen text-white rounded-full;
   @apply text-lg font-medium transition-all duration-300;
   @apply hover:shadow-lg hover:scale-105 hover:bg-lightGreen/90;
-}
-
-.placeholder-section {
-  @apply py-16 px-4 bg-snowGray;
-}
-
-.placeholder-title {
-  @apply text-2xl md:text-3xl text-center text-gray mb-12 lowercase;
-}
-
-.placeholder-grid {
-  @apply grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 max-w-6xl mx-auto;
-}
-
-.placeholder-card {
-  @apply rounded-2xl shadow-3xl overflow-hidden;
-  @apply opacity-0;
-  animation: fadeInUp 0.5s ease-out forwards;
-}
-
-.placeholder-image {
-  @apply h-48 bg-gradient-to-br from-gray/10 to-gray/20;
-  @apply animate-pulse;
-}
-
-.placeholder-content {
-  @apply p-6 space-y-3;
-}
-
-.placeholder-line {
-  @apply h-4 bg-gray/20 rounded animate-pulse;
-}
-
-@keyframes float {
-  0%, 100% {
-    transform: translateY(0);
-  }
-  50% {
-    transform: translateY(-10px);
-  }
-}
-
-@keyframes fadeInUp {
-  from {
-    opacity: 0;
-    transform: translateY(20px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
+  @apply focus:outline-none focus:ring-2 focus:ring-lightGreen focus:ring-offset-2;
 }
 </style>

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -1,5 +1,42 @@
+export type ProjectCategory = 'landing-page' | 'e-commerce' | 'corporate' | 'portfolio' | 'custom';
+export type ProjectSize = 'major' | 'simple';
+
+export interface ProjectImage {
+  src: string;
+  alt: string;
+  caption?: string;
+}
+
+export interface ProjectTestimonial {
+  quote: string;
+  author: string;
+  role?: string;
+  company?: string;
+}
+
 export interface Project {
-    imagesrc: string;
-    imageAlt: string;
-    link: string;
+  id: string;
+  slug: string;
+  title: string;
+  shortDescription: string;
+  fullDescription?: string;
+  category: ProjectCategory;
+  size: ProjectSize;
+  featured: boolean;
+  thumbnail: ProjectImage;
+  heroImage: ProjectImage;
+  gallery?: ProjectImage[];
+  technologies: string[];
+  clientName?: string;
+  liveUrl?: string;
+  testimonial?: ProjectTestimonial;
+  completedDate: string;
+  order: number;
+}
+
+// Legacy interface for backward compatibility with Carousel component
+export interface LegacyProject {
+  imagesrc: string;
+  imageAlt: string;
+  link: string;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -42,7 +42,7 @@
     // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
     // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
     // "noUncheckedSideEffectImports": true,             /* Check side effect imports. */
-    // "resolveJsonModule": true,                        /* Enable importing .json files. */
+    "resolveJsonModule": true,                           /* Enable importing .json files. */
     // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
     // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import Pages from 'vite-plugin-pages'
-import { viteObfuscateFile } from 'vite-plugin-obfuscator';
+import vitePluginBundleObfuscator from 'vite-plugin-bundle-obfuscator';
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -9,10 +9,14 @@ export default defineConfig({
   plugins: [
     vue(),
     Pages(),
-    viteObfuscateFile({
-      global: true, 
-      stringArray: true, 
-      transformObjectKeys: true, 
+    vitePluginBundleObfuscator({
+      enable: true,
+      log: false,
+      autoExcludeNodeModules: true,
+      options: {
+        stringArray: true,
+        transformObjectKeys: true,
+      }
     }),
   ],
   build: {


### PR DESCRIPTION
## Summary
- Add reusable portfolio components: PortfolioCard, PortfolioGrid, PortfolioFilter, PortfolioDetailModal, ProjectGallery, ProjectTestimonial
- Add project data structure with category-based filtering
- Include comprehensive tests for new components

## Test plan
- [x] All 77 tests pass
- [ ] Manual verification of portfolio page functionality
- [ ] Verify filtering works correctly
- [ ] Verify detail modal opens and displays project info